### PR TITLE
feature: Read genetic distance data from the VCF directly. No map file necessary.

### DIFF
--- a/src/hapibd/HapIbdPar.java
+++ b/src/hapibd/HapIbdPar.java
@@ -38,6 +38,7 @@ public final class HapIbdPar {
     // data input/output parameters
     private final File gt;
     private final File map;
+    private final boolean useVcfMap;
     private final String out;
     private final File excludesamples;
 
@@ -79,7 +80,8 @@ public final class HapIbdPar {
         // data input/output parameters
         gt = Validate.getFile(Validate.stringArg("gt", argsMap, true, null,
                 null));
-        map = Validate.getFile(Validate.stringArg("map", argsMap, true, null, null));
+        useVcfMap = Validate.booleanArg("vcf-has-cm", argsMap, false, false);
+        map = Validate.getFile(Validate.stringArg("map", argsMap, false, null, null));
         out = Validate.stringArg("out", argsMap, true, null, null);
         excludesamples = Validate.getFile(Validate.stringArg("excludesamples",
                 argsMap, false, null, null));
@@ -154,6 +156,14 @@ public final class HapIbdPar {
      */
     public File map() {
         return map;
+    }
+
+    /**
+     * Returns if we should get genetic position from the VCF
+     * @return useVcfMap boolean
+     */
+    public boolean useVcfMap() {
+        return useVcfMap;
     }
 
     /**

--- a/src/hapibd/PbwtIbdDriver.java
+++ b/src/hapibd/PbwtIbdDriver.java
@@ -62,8 +62,7 @@ public final class PbwtIbdDriver {
      * @throws NullPointerException if {@code par == null}
      */
     public static long[] detectIbd(HapIbdPar par) {
-        ChromInterval chromInt = null;
-        GeneticMap genMap = GeneticMap.geneticMap(par.map(), chromInt);
+        GeneticMap genMap = GeneticMap.geneticMap(par, null);
         long[] nSamplesAndMarkers = new long[2];
         File hbdFile = new File(par.out() + ".hbd.gz");
         File ibdFile = new File(par.out() + ".ibd.gz");

--- a/src/vcf/GeneticMap.java
+++ b/src/vcf/GeneticMap.java
@@ -18,6 +18,8 @@
 package vcf;
 
 import beagleutil.ChromInterval;
+import hapibd.HapIbdPar;
+
 import java.io.File;
 
 /**
@@ -109,17 +111,21 @@ public interface GeneticMap {
      * @throws IllegalArgumentException if all base positions on a chromosome
      * have the same genetic map position
      */
-    static GeneticMap geneticMap(File file, ChromInterval chromInt) {
-        if (file==null) {
+    static GeneticMap geneticMap(HapIbdPar par, ChromInterval chromInt) {
+        if (par.useVcfMap()) {
+            return new VcfGeneticMap();
+        }
+
+        if (par.map()==null) {
             double scaleFactor = 1e-6;
             return new PositionMap(scaleFactor);
         }
         else {
             if (chromInt==null) {
-                return PlinkGenMap.fromPlinkMapFile(file);
+                return PlinkGenMap.fromPlinkMapFile(par.map());
             }
             else {
-                return PlinkGenMap.fromPlinkMapFile(file, chromInt.chrom());
+                return PlinkGenMap.fromPlinkMapFile(par.map(), chromInt.chrom());
             }
         }
     }

--- a/src/vcf/Marker.java
+++ b/src/vcf/Marker.java
@@ -46,6 +46,12 @@ public interface Marker extends Comparable<Marker> {
     int pos();
 
     /**
+     * Returns the genetic position
+     * @return the genetic position in CM
+     */
+    double geneticPos();
+
+    /**
      * Returns the number of marker identifiers.
      * @return the number of marker identifiers
      */

--- a/src/vcf/VcfGeneticMap.java
+++ b/src/vcf/VcfGeneticMap.java
@@ -1,0 +1,61 @@
+package vcf;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+public class VcfGeneticMap implements GeneticMap {
+    /**
+     * Returns the base position corresponding to the specified genetic map
+     * position. If the genetic position is not a map position then the base
+     * position is estimated from the nearest genetic map positions using
+     * linear interpolation.
+     *
+     * @param chrom           the chromosome index
+     * @param geneticPosition the genetic position on the chromosome
+     * @return the base position corresponding to the specified genetic map
+     * position
+     * @throws IllegalArgumentException  if the calculated base position
+     *                                   exceeds {@code Integer.MAX_VALUE}
+     * @throws IllegalArgumentException  if this genetic map has no
+     *                                   map positions for the specified chromosome
+     * @throws IndexOutOfBoundsException if
+     *                                   {@code chrom < 0 || chrom >= ChromIds.instance().size()}
+     */
+    @Override
+    public int basePos(int chrom, double geneticPosition) {
+        // VcfGeneticMap cannot go from genetic to physical position
+        // At this time, this method is not used
+        throw new NotImplementedException();
+    }
+
+    /**
+     * Returns the genetic map position of the specified marker. The
+     * genetic map position is estimated using linear interpolation.
+     *
+     * @param marker a genetic marker
+     * @return the genetic map position of the specified marker
+     * @throws IllegalArgumentException if this genetic map has no
+     *                                  map positions for the specified chromosome
+     * @throws NullPointerException     if {@code marker == null}
+     */
+    @Override
+    public double genPos(Marker marker) {
+        return marker.geneticPos();
+    }
+
+    /**
+     * Returns the genetic map position of the specified genome coordinate.
+     * The genetic map position is estimated using linear interpolation.
+     *
+     * @param chrom        the chromosome index
+     * @param basePosition the base coordinate on the chromosome
+     * @return the genetic map position of the specified genome coordinate
+     * @throws IllegalArgumentException  if this genetic map has no
+     *                                   map positions for the specified chromosome
+     * @throws IndexOutOfBoundsException if
+     *                                   {@code chrom < 0 || chrom >= ChromIds.instance().size()}
+     */
+    @Override
+    public double genPos(int chrom, int basePosition) {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
shapeit4 output includes cM for each marker in the INFO column, like so:

```
##INFO=<ID=CM,Number=A,Type=Float,Description="Interpolated cM position">
```

This PR adds a new flag: vcf-has-cm, which will use the genetic position reported from the VCF file, rather that needing a genetic map and interpolating. This allows directly using the reported genetic position for each marker.

I know that you prefer email, so I'm sending one with more context. 